### PR TITLE
Fix a Strict standards warning

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -4,15 +4,16 @@ use lithium\core\Libraries;
 use lithium\action\Dispatcher;
 use lithium\core\Environment;
 
-Dispatcher::applyFilter('_callable', function($self, $params, $chain) {	
-	
+Dispatcher::applyFilter('_callable', function($self, $params, $chain) {
+
 	$controller = $chain->next($self, $params, $chain);
 
-	if (Environment::is('production') && extension_loaded ('newrelic')) {
-		$controllerName = preg_replace('/Controller$/', '', array_pop(explode('\\', get_class($controller))));
-		newrelic_name_transaction ($controllerName.'/'.$params['request']->params['action']);
+	if (Environment::is('production') && extension_loaded('newrelic')) {
+		$ctrl = explode('\\', get_class($controller));
+		$controllerName = preg_replace('/Controller$/', '', array_pop($ctrl));
+		newrelic_name_transaction(strtolower($controllerName) . '/' . $params['request']->params['action']);
 	}
-	
+
 	return $controller;
 });
 


### PR DESCRIPTION
My errors rates went crazy due to a bad variable reference which cause a `Strict standards: Only variables should be passed by reference`
Fixed by using a temp variable `$ctrl`
- Minor QA and whitespaces cleaning...
