### PR TITLE
Fix return of call_user_func_array

### DIFF
--- a/extensions/Newrelic.php
+++ b/extensions/Newrelic.php
@@ -26,8 +26,7 @@ class Newrelic extends StaticObject {
 	 */
 	public static function __callStatic($method, array $params = array()) {
 		if (static::shouldRun()) {
-			call_user_func_array($function = "newrelic_{$method}", $params);
-			return $function;
+			return call_user_func_array("newrelic_{$method}", $params);
 		}
 		return false;
 	}

--- a/tests/cases/extensions/NewrelicTest.php
+++ b/tests/cases/extensions/NewrelicTest.php
@@ -59,9 +59,11 @@ class NewrelicTest extends Unit {
 		NewrelicMock::applyFilter('shouldRun', function($self, $params, $chain) {
 			return true;
 		});
-		Mocker::overwriteFunction('li3_newrelic\extensions\call_user_func_array', function() {
-			return;
+
+		Mocker::overwriteFunction('li3_newrelic\extensions\call_user_func_array', function($function_name) {
+			return $function_name;
 		});
+
 		$result = NewrelicMock::custom_metric();
 
 		$this->assertIdentical('newrelic_custom_metric', $result);


### PR DESCRIPTION
Fixes the master branch to return the output from the `newrelic_*` methods, such as `newrelic_get_browser_timing_header`
